### PR TITLE
Update build workflow to use the correct path for hot-reload executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,4 @@ jobs:
           chmod +x test_build.sh
           echo 'int main(){return 0;}' > test.c
           gcc test.c -o a.out
-          timeout 3s valgrind --leak-check=full --error-exitcode=1 ./hot-reload . ./test_build.sh ./a.out || true
+          timeout 3s valgrind --leak-check=full --error-exitcode=1 ./build/bin/hot-reload . ./test_build.sh ./a.out || true


### PR DESCRIPTION
This pull request makes a minor update to the build workflow by changing the path used to run the `hot-reload` binary, ensuring it is executed from the correct build output directory.

* Updated the build workflow to run `hot-reload` from `./build/bin/hot-reload` instead of the project root, improving consistency with build output paths.